### PR TITLE
make zPatch the default patch name

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ registerPatcher({
     templateUrl: `${patcherUrl}/partials/settings.html`,
     defaultSettings: {
       title: info.name,
-      patchFileName: 'Reading is Good - Patch.esp'
+      patchFileName: 'zPatch.esp'
     }
   },
   requiredFiles: [ 'Reading Is Good 2.esp' ],


### PR DESCRIPTION
Unless you're adding huge numbers of records, it's probably better to add your patch to zPatch, rather than having a generated patch with only a handful of records.